### PR TITLE
fix: add .nojekyll to prevent GitHub Pages Jekyll processing

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -69,6 +69,9 @@ jobs:
           # Copy built files to root (excluding pr-* directories)
           cp -r ${{ github.workspace }}/public/* "$TEMP_DIR/"
           
+          # Add .nojekyll to prevent GitHub Pages from processing with Jekyll
+          touch "$TEMP_DIR/.nojekyll"
+          
           # Navigate to temp directory and push
           cd "$TEMP_DIR"
           git add .

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -68,6 +68,9 @@ jobs:
           # Copy built files to pr directory
           cp -r ${{ github.workspace }}/public/* "$TEMP_DIR/pr-${{ github.event.pull_request.number }}/"
           
+          # Add .nojekyll to prevent GitHub Pages from processing with Jekyll
+          touch "$TEMP_DIR/.nojekyll"
+          
           # Navigate to temp directory and push
           cd "$TEMP_DIR"
           git add .


### PR DESCRIPTION
GitHub Pages was automatically trying to build the site with Jekyll. Adding .nojekyll file tells GitHub to serve the Hugo-built site directly.