### PR TITLE
fix: correct concurrency group for prod-deploy workflow

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -13,6 +13,10 @@ defaults:
   run:
     shell: bash
 
+concurrency:
+  group: ${{ github.event.number }}
+  cancel-in-progress: true
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes concurrency configuration in prod-deploy.yml. The previous group used  which is only available for PR events, not push events.

Changes:
- Use static 'prod-deploy' concurrency group
- Enables workflow to cancel in-progress runs when triggered by push to main
- Matches the workflow's actual trigger (push to main, not PR events)